### PR TITLE
Fix usage of "C#" and ".NET" throughout wiki site

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -1,4 +1,7 @@
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -30,7 +33,8 @@ jobs:
         python-version: '3.10'
     - run: pip install jupyter
 
-    - name: Publish to GitHub Pages (and render) 
+    - name: Publish to GitHub Pages
+      if: ${{ github.event_name == 'push' }}
       uses: quarto-dev/quarto-actions/publish@v2
       with:
         target: gh-pages

--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -33,6 +33,12 @@ jobs:
         python-version: '3.10'
     - run: pip install jupyter
 
+    - name: Render Quarto Project
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: quarto-dev/quarto-actions/render@v2
+      with:
+        to: html
+
     - name: Publish to GitHub Pages
       if: ${{ github.event_name == 'push' }}
       uses: quarto-dev/quarto-actions/publish@v2

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # ITS Propagation Library Wiki
 
+[![NTIA/ITS PropLib][proplib-badge]][proplib-link]
 [![Site Build and Deploy Status][gh-actions-badge]][gh-actions-link]
+[![GitHub Issues][gh-issues-badge]][gh-issues-link]
 
-[gh-actions-badge]: https://github.com/NTIA/propagation-library-wiki/actions/workflows/quarto-publish.yml/badge.svg
+[proplib-badge]: https://img.shields.io/badge/PropLib-badge?label=%F0%9F%87%BA%F0%9F%87%B8%20NTIA%2FITS&labelColor=162E51&color=D63E04
+[proplib-link]: https://ntia.github.io/propagation-library-wiki
+[gh-actions-badge]: https://img.shields.io/github/actions/workflow/status/NTIA/propagation-library-wiki/quarto-publish.yml?branch=main&logo=quarto&label=Render%20%26%20Publish&labelColor=162E51
 [gh-actions-link]: https://ntia.github.io/propagation-library-wiki
+[gh-issues-badge]: https://img.shields.io/github/issues/NTIA/propagation-library-wiki?logo=github&label=Issues&labelColor=162E51
+[gh-issues-link]: https://github.com/NTIA/proplib-template/issues
 
 This repository hosts wiki pages for the suite of softwares comprising the
 ITS Propagation Library. The wiki is generated with [Quarto](https://quarto.org/)

--- a/includes/_getting_started.qmd
+++ b/includes/_getting_started.qmd
@@ -3,6 +3,6 @@
 This page documents the inputs, outputs, and primary functions of this software in a language-agnostic way. Language-specific documentation is additionally provided for this library. The pages linked below include installation instructions as well as usage examples for each supported language.
 
 [C++](cpp.qmd){.btn .btn-secondary role="button"}
-[C#/.NET](dotnet.qmd){.btn .btn-secondary role="button"}
+[.NET](dotnet.qmd){.btn .btn-secondary role="button"}
 [MATLAB](matlab.qmd){.btn .btn-secondary role="button"}
 [Python](python.qmd){.btn .btn-secondary role="button"}

--- a/index.qmd
+++ b/index.qmd
@@ -1,10 +1,10 @@
 ---
 title: "ITS Propagation Library Wiki"
 date: 2024-06-11
-date-modified: 2024-06-11
+date-modified: 2024-11-20
 ---
 
-The ITS Propagation Library (**"PropLib"**) is a collection of open source software developed by [ITS](about.qmd), focused on modeling radio wave propagation under a wide variety of circumstances. The library currently supports C++, C#/.NET, MATLAB, and Python users through exposing common functionality across multiple programming environments. One of the key benefits of this approach is that users are assured of identical results across languages, allowing researchers to work in their most efficient development environment while benefitting from common library improvements.
+The ITS Propagation Library (**"PropLib"**) is a collection of open source software developed by [ITS](about.qmd), focused on modeling radio wave propagation under a wide variety of circumstances. The library currently supports C++, .NET, MATLAB®, and Python users through exposing common functionality across multiple programming environments. One of the key benefits of this approach is that users are assured of identical results across languages, allowing researchers to work in their most efficient development environment while benefitting from common library improvements.
 
 ## Packages
 

--- a/models/ITM/dotnet.qmd
+++ b/models/ITM/dotnet.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Irregular Terrain Model (ITM) – C#/.NET"
+title: "Irregular Terrain Model (ITM) – .NET"
 ---
 
 {{< include /includes/_under_construction.qmd >}}
@@ -21,6 +21,8 @@ using ITS.Propagation;
 The `itm` library is packaged to support IntelliSense when developing in Visual Studio.  This documentation will provide the developer with information on function descriptions, variable details, etc.
 
 # Examples
+
+The following code examples show how to use C# to call ITM functions from the .NET package.
 
 **Note:** These examples use an artificial terrain profile.
 

--- a/models/P2108/cpp.qmd
+++ b/models/P2108/cpp.qmd
@@ -1,5 +1,7 @@
 ---
 title: "ITU-R P.2108 – C++"
+date: 2024-07-09
+date-modified: 2024-11-20
 ---
 
 {{< include /includes/_under_construction.qmd >}}

--- a/models/P2108/dotnet.qmd
+++ b/models/P2108/dotnet.qmd
@@ -1,5 +1,5 @@
 ---
-title: "ITU-R P.2108 – C#/.NET"
+title: "Recommendation ITU-R P.2108 – .NET"
 ---
 
 {{< include /includes/_under_construction.qmd >}}
@@ -13,6 +13,8 @@ title: "ITU-R P.2108 – C#/.NET"
 {{< include /includes/_under_construction.qmd >}}
 
 # Examples
+
+The following code examples show how to use C# to call P.2108 functions from the .NET package.
 
 ## Height Gain Terminal Correction Model
 

--- a/models/P2108/index.qmd
+++ b/models/P2108/index.qmd
@@ -1,7 +1,7 @@
 ---
-title: "ITU-R P.2108"
+title: "Recommendation ITU-R P.2108"
 date: 2024-06-28
-date-modified: 2024-06-28
+date-modified: 2024-11-20
 ---
 
 Recommendation ITU-R P.2108 _Prediction of clutter loss_ contains three methods for the prediction of clutter loss: the [Height Gain Terminal Correction Model](#height-gain-terminal-correction-model), [Terrestrial Statistical Model](#terrestrial-statistical-model), and [Aeronautical Statistical Model](#aeronautical-statistical-model) [@p2108-1, Sections 3.1-3.3]. This software implements each of the three models.
@@ -44,7 +44,7 @@ This table also provides the integer values mapped to each clutter type in the e
 {{< include /includes/_code_examples.qmd >}}
 
 [C++](cpp.qmd#height-gain-terminal-correction-model){.btn .btn-secondary role="button"}
-[C#/.NET](dotnet.qmd#height-gain-terminal-correction-model){.btn .btn-secondary role="button"}
+[.NET](dotnet.qmd#height-gain-terminal-correction-model){.btn .btn-secondary role="button"}
 [MATLAB](matlab.qmd#height-gain-terminal-correction-model){.btn .btn-secondary role="button"}
 [Python](python.qmd#height-gain-terminal-correction-model){.btn .btn-secondary role="button"}
 
@@ -64,7 +64,7 @@ This model calculates an additional loss, $L_{ctt}$, which can be added to the t
 {{< include /includes/_code_examples.qmd >}}
 
 [C++](cpp.qmd#terrestrial-statistical-model){.btn .btn-secondary .btn role="button"}
-[C#/.NET](dotnet.qmd#terrestrial-statistical-model){.btn .btn-secondary .btn role="button"}
+[.NET](dotnet.qmd#terrestrial-statistical-model){.btn .btn-secondary .btn role="button"}
 [MATLAB](matlab.qmd#terrestrial-statistical-model){.btn .btn-secondary .btn role="button"}
 [Python](python.qmd#terrestrial-statistical-model){.btn .btn-secondary .btn role="button"}
 
@@ -86,6 +86,6 @@ The method used to develop this model is described in @p2402-0.
 {{< include /includes/_code_examples.qmd >}}
 
 [C++](cpp.qmd#aeronautical-statistical-model){.btn .btn-secondary .btn role="button"}
-[C#/.NET](dotnet.qmd#aeronautical-statistical-model){.btn .btn-secondary .btn role="button"}
+[.NET](dotnet.qmd#aeronautical-statistical-model){.btn .btn-secondary .btn role="button"}
 [MATLAB](matlab.qmd#aeronautical-statistical-model){.btn .btn-secondary .btn role="button"}
 [Python](python.qmd#aeronautical-statistical-model){.btn .btn-secondary .btn role="button"}

--- a/models/P2108/matlab.qmd
+++ b/models/P2108/matlab.qmd
@@ -1,5 +1,5 @@
 ---
-title: "ITU-R P.2108 – MATLAB"
+title: "Recommendation ITU-R P.2108 – MATLAB"
 ---
 
 {{< include /includes/_under_construction.qmd >}}

--- a/models/P2108/python.qmd
+++ b/models/P2108/python.qmd
@@ -1,7 +1,7 @@
 ---
-title: "ITU-R P.2108 – Python"
+title: "Recommendation ITU-R P.2108 – Python"
 date: 2024-06-25
-date-modified: 2024-06-25
+date-modified: 2024-11-20
 ---
 
 This page details the installation and usage of the Python version of the U.S. Reference Implementation of Recommendation ITU-R P.2108.


### PR DESCRIPTION
Also modify the GitHub Action workflow so that the quarto site will render when pull requests into `main` are made (like this one!). They still only deploy changes when a commit is made to `main` (e.g. when a pull request is approved and merged).
